### PR TITLE
MFA: 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ If you are interested in contributing on any of these tasks please reach out!
 - Implement Automated Testing
 - Support Recovery Keys (Keys generated at time of setting up MFA which can be used when no other method is available)
 - Add "Login other device" support: generate an OTP from a device capable of using U2F to be entered on a device not capable of U2F
-- Support TOTPs (Google Authenticator, Authy)
 - Support requiring more then 2 factors to authenticate
 - Passwordless
 

--- a/mfa-client.js
+++ b/mfa-client.js
@@ -227,4 +227,7 @@ export default {
     
     finishRegisterTOTP,
     registerTOTP,
+    
+    // DEPRECATED in 0.0.3
+    solve:solveU2FChallenge,
 };

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ndev:mfa',
-  version: '0.0.2',
+  version: '0.0.3',
   summary: 'Multi Factor Authentication for Meteor (with U2F support)',
   git: 'https://github.com/TheRealNate/meteor-mfa',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,14 +1,15 @@
 Package.describe({
   name: 'ndev:mfa',
   version: '0.0.3',
-  summary: 'Multi Factor Authentication for Meteor (with U2F support)',
+  summary: 'Multi Factor Authentication for Meteor (supporting U2F, TOTP, and OTP)',
   git: 'https://github.com/TheRealNate/meteor-mfa',
   documentation: 'README.md'
 });
 
 Npm.depends({
   "@webauthn/server":"0.1.3",
-  "@webauthn/client":"0.1.3"
+  "@webauthn/client":"0.1.3",
+  "otplib":"12.0.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
**Client Changelog:**
- Rename `MFA.solve` to `MFA. solveU2FChallenge`. Note: `MFA.solve will remain as a reference to `MFA.solveU2FChallenge` for backwards compatibility until next major version.
- Add new private method `assembleChallengeCompletionArguments`, which consolidates shared code from resetPassword, finishLogin, and solveChallenge
- Add new universal `MFA.solveChallenge` method, capable of solving challenges for all 3 MFA methods
- TOTP Support (add `MFA.registerTOTP` and `MFA.finishRegisterTOTP` methods)

**Server Changelog:**
- Add `config.enableTOTP` option (defaults to true)
- Add new universal `MFA.verifyChallenge` method, capable of verifying solved challenges for all 3 MFA methods
- Add handlers for starting and finishing registration for TOTP